### PR TITLE
Plumb placeholder attribute through to io-string.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "io-menu",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "homepage": "https://github.com/arodic/io-menu",
   "authors": [
     "Aleksandar Rodic <aleksandar.xyz@gmail.com>"

--- a/io-menu.html
+++ b/io-menu.html
@@ -37,6 +37,7 @@ Example:
     </template>
     <io-string style="display: {{search ? 'block' : 'none'}}" id="search"
       updateImmediate
+      placeholder="{{placeholder}}"
       value="{{searchString}}"
       on-keydown="{{onSearchKeyUp}}">
     </io-string>
@@ -102,6 +103,15 @@ Example:
          * @default true
          */
         expanded: {value: false, reflect: true},
+
+        /**
+         * Placeholder text shown on empty input.
+         *
+         * @attribute placeholder
+         * @type string
+         * @default "string"
+         */
+        placeholder: {value:"string", reflect: true},
 
         /**
          * Should the menu stay open when an action is selected/clicked?


### PR DESCRIPTION
This allows users of io-menu to customize the placeholder string.
