### PR TITLE
open menu directly next to its parent.

### DIFF
--- a/io-menu.html
+++ b/io-menu.html
@@ -485,6 +485,9 @@ Example:
               }.bind(this));
             }
           }.bind(this));
+          var rect = this._parent.getBoundingClientRect();
+          this.style.top = rect.top + 'px';
+          this.style.left = rect.right + 'px';
           this.openOverlay();
           this.startAnimation();
         } else {


### PR DESCRIPTION
Originally it opened directly on top of its parent, then
b160e08db9a866d4d1b46a12d0f5fde854c7b4ac introduced a bug
that caused it to open at (0,0). Now we open it to
the right of the parent because that's where we actually
want it to be in all flux maker tools uses.
